### PR TITLE
pObj->is<OBJ_TYPE>() is now true for full replacement for dynamic_cast

### DIFF
--- a/creatures.cpp
+++ b/creatures.cpp
@@ -65,7 +65,7 @@ public:
     template <typename T>
     bool is() const noexcept
     {
-        return is_base_id(T::id());
+        return is_base_id(T::id()) || T::id() == who();;
     }
 
     virtual bool is_base_id(const class_id& base_id) const noexcept


### PR DESCRIPTION
if object type != base class type, `pObj->is<OBJ_TYPE>()` wrongly returns false (unlike dynamic_cast behaviour which returns not nullptr with `p = dynamic_cast<OBG_TYPE*>(pObj)`